### PR TITLE
Fix Docker container libgcc_s.so.1 dependency issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 
 # Build the application with static linking
-ENV RUSTFLAGS="-C target-feature=-crt-static"
+ENV RUSTFLAGS="-C target-feature=+crt-static"
 
 # Set target based on architecture
 ARG TARGETPLATFORM

--- a/tests/test_config_loading.rs
+++ b/tests/test_config_loading.rs
@@ -25,7 +25,7 @@ fn test_env_file_loading() {
     let mut cmd = Command::cargo_bin("paperless-ngx-ocr2").unwrap();
     let assert = cmd
         .arg("--file")
-        .arg("test.pdf")
+        .arg(pdf_file.to_str().unwrap())
         .env("PAPERLESS_OCR_API_KEY", "test_key_from_env")
         .env("PAPERLESS_OCR_API_BASE_URL", "https://test.api.com")
         .assert();
@@ -74,7 +74,7 @@ api_base_url = "https://home.api.com"
 
     // Run the command - should use current directory config (priority)
     let mut cmd = Command::cargo_bin("paperless-ngx-ocr2").unwrap();
-    let assert = cmd.arg("--file").arg("test.pdf").assert();
+    let assert = cmd.arg("--file").arg(pdf_file.to_str().unwrap()).assert();
 
     // Should fail with API error (not config error) because current dir config was loaded
     assert
@@ -109,7 +109,7 @@ api_base_url = "https://custom.api.com"
     let mut cmd = Command::cargo_bin("paperless-ngx-ocr2").unwrap();
     let assert = cmd
         .arg("--file")
-        .arg("test.pdf")
+        .arg(pdf_file.to_str().unwrap())
         .arg("--config")
         .arg(custom_config.to_str().unwrap())
         .env("PAPERLESS_OCR_API_KEY", "custom_config_key")
@@ -137,7 +137,7 @@ fn test_config_file_not_found() {
     let mut cmd = Command::cargo_bin("paperless-ngx-ocr2").unwrap();
     let assert = cmd
         .arg("--file")
-        .arg("test.pdf")
+        .arg(pdf_file.to_str().unwrap())
         .arg("--config")
         .arg("nonexistent_config.toml")
         .assert();


### PR DESCRIPTION
## Problem
The Docker container was failing to run with the following error:
```
Error loading shared library libgcc_s.so.1: No such file or directory (needed by /usr/local/bin/paperless-ngx-ocr2)
Error relocating /usr/local/bin/paperless-ngx-ocr2: _Unwind_GetRegionStart: symbol not found
Error relocating /usr/local/bin/paperless-ngx-ocr2: _Unwind_SetGR: symbol not found
Error relocating /usr/local/bin/paperless-ngx-ocr2: _Unwind_GetDataRelBase: symbol not found
Error relocating /usr/local/bin/paperless-ngx-ocr2: _Unwind_GetLanguageSpecificData: symbol not found
Error relocating /usr/local/bin/paperless-ngx-ocr2: _Unwind_GetIP: symbol not found
Error relocating /usr/local/bin/paperless-ngx-ocr2: _Unwind_Backtrace: symbol not found
Error relocating /usr/local/bin/paperless-ngx-ocr2: _Unwind_GetIPInfo: symbol not found
Error relocating /usr/local/bin/paperless-ngx-ocr2: _Unwind_GetTextRelBase: symbol not found
Error relocating /usr/local/bin/paperless-ngx-ocr2: _Unwind_Resume: symbol not found
Error relocating /usr/local/bin/paperless-ngx-ocr2: _Unwind_SetIP: symbol not found
```

## Root Cause
The binary was being built with dynamic linking, expecting glibc libraries that aren't available in the Alpine Linux runtime container. The Dockerfile was using `RUSTFLAGS="-C target-feature=-crt-static"` which explicitly disabled static linking.

## Solution
Changed the RUSTFLAGS to enable static linking:
```diff
- ENV RUSTFLAGS="-C target-feature=-crt-static"
+ ENV RUSTFLAGS="-C target-feature=+crt-static"
```

## Testing
- ✅ Container builds successfully
- ✅ Binary runs without dependency errors
- ✅ `ldd` command confirms binary is statically linked ("Not a valid dynamic program")
- ✅ Help output displays correctly

## Impact
- Container now runs correctly on Alpine Linux without external library dependencies
- Binary is fully self-contained and portable
- No breaking changes to functionality

## Note
This is a clean version of the fix based on the latest main branch, resolving the merge conflicts from the previous PR.